### PR TITLE
added VERSION because EUM complains about not being able to set it

### DIFF
--- a/lib/B/Hooks/EndOfScope.pm
+++ b/lib/B/Hooks/EndOfScope.pm
@@ -4,6 +4,8 @@ package B::Hooks::EndOfScope;
 use strict;
 use warnings;
 
+our $VERSION = '0.13';
+
 # note - a %^H tie() fallback will probably work on 5.6 as well,
 # if you need to go that low - sane patches passing *all* tests
 # will be gladly accepted


### PR DESCRIPTION
When running 'perl Makefile.PL' I got
WARNING: Setting VERSION via file 'lib/B/Hooks/EndOfScope.pm' failed
This PR adds the VERSION.