### PR TITLE
EUM and Dist::Zilla changes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,11 +11,23 @@ installer = none    ; we supply our own, below
 surgical_podweaver = 1
 -remove = AutoPrereqs       ; avoid detecting conditional prereqs
 -remove = PodCoverageTests  ; TODO
+-remove = PkgVersion
+-remove = Git::NextVersion
 Authority.authority = cpan:FLORA
 Git::Tag.tag_format = %v
 Git::NextVersion.version_regexp = ^(.+)$
 Test::Version.has_version = 0   ; for internal modules (FIXME: new option forthcoming)
 Test::MinimumVersion.max_target_perl = 5.008001
+
+[RewriteVersion]
+
+[BumpVersionAfterRelease]
+
+[Git::Commit / bumped $VERSION after release]
+allow_dirty_match = ^lib
+commit_msg = After release: bump $VERSION
+
+[Git::Push / push $VERSION bump]
 
 [Prereqs]
 Module::Runtime = 0.012

--- a/lib/B/Hooks/EndOfScope.pm
+++ b/lib/B/Hooks/EndOfScope.pm
@@ -4,7 +4,7 @@ package B::Hooks::EndOfScope;
 use strict;
 use warnings;
 
-our $VERSION = '0.13';
+our $VERSION = '0.14';
 
 # note - a %^H tie() fallback will probably work on 5.6 as well,
 # if you need to go that low - sane patches passing *all* tests

--- a/lib/B/Hooks/EndOfScope/PP.pm
+++ b/lib/B/Hooks/EndOfScope/PP.pm
@@ -4,6 +4,8 @@ package B::Hooks::EndOfScope::PP;
 use warnings;
 use strict;
 
+our $VERSION = '0.14';
+
 use Module::Runtime 'require_module';
 use constant _PERL_VERSION => "$]";
 

--- a/lib/B/Hooks/EndOfScope/PP/FieldHash.pm
+++ b/lib/B/Hooks/EndOfScope/PP/FieldHash.pm
@@ -7,6 +7,8 @@ package # hide from pause
 use strict;
 use warnings;
 
+our $VERSION = '0.14';
+
 use warnings;
 use strict;
 

--- a/lib/B/Hooks/EndOfScope/PP/HintHash.pm
+++ b/lib/B/Hooks/EndOfScope/PP/HintHash.pm
@@ -9,6 +9,8 @@ use strict;
 use warnings;
 use Scalar::Util ();
 
+our $VERSION = '0.14';
+
 # This is the original implementation, which sadly is broken
 # on perl 5.10+ within string evals
 sub on_scope_end (&) {

--- a/lib/B/Hooks/EndOfScope/XS.pm
+++ b/lib/B/Hooks/EndOfScope/XS.pm
@@ -4,6 +4,8 @@ package B::Hooks::EndOfScope::XS;
 use strict;
 use warnings;
 
+our $VERSION = '0.14';
+
 BEGIN {
   require Module::Runtime;
   # Adjust the Makefile.PL if changing this minimum version


### PR DESCRIPTION
Karen,

sorry, sorry, sorry for the delay.  Unfortunately I got a little bit too busy in the last weeks what was actually not planned so that I almost forgot about this.  I know, I need to get better in time management.  I hope you're still in for discussing another PR (although it's already February):
- added $VERSION to the other modules
- changed dist.ini as proposed

So now I added $VERSION to all of the modules and altered the dist.ini as well.

That now leads to `[DZ] attempted to set version twice` when running `dzil build` although I added `-remove = PkgVersion` *and* `-remove Git::NextVersion` to the dist.ini -- and -- I guess is exactly what you anticipated when declining my first PR, right?

So is there actually an *either* Dist::Zilla *or* EUM but not both?