### PR TITLE
Remove Tie::StdHash from prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,7 +23,6 @@ module = Carp
 module = Hash::Util::FieldHash
 module = Scalar::Util
 module = Tie::Hash
-module = Tie::StdHash
 module = base
 module = constant
 
@@ -51,7 +50,6 @@ Devel::Hide = 0.0007            ; releasers *must* test both the XS and PP paths
 -raw = |  $WriteMakefileArgs{PREREQ_PM}{'Hash::Util::FieldHash'} = $FallbackPrereqs{'Hash::Util::FieldHash'} = 0;
 -raw = |  $WriteMakefileArgs{PREREQ_PM}{'Scalar::Util'} = $FallbackPrereqs{'Scalar::Util'} = 0;
 -raw = |  $WriteMakefileArgs{PREREQ_PM}{'Tie::Hash'} = $FallbackPrereqs{'Tie::Hash'} = 0;
--raw = |  $WriteMakefileArgs{PREREQ_PM}{'Tie::StdHash'} = $FallbackPrereqs{'Tie::StdHash'} = 0;
 -raw = |  $WriteMakefileArgs{PREREQ_PM}{'base'} = $FallbackPrereqs{'base'} = 0;
 -raw = |  $WriteMakefileArgs{PREREQ_PM}{'constant'} = $FallbackPrereqs{'constant'} = 0;
 -raw = |}


### PR DESCRIPTION
Tie::StdHash doesn't exist as a require-able module, hence no Module::Metadata inspection either.

The problem only happens when you don't have a working C compiler, since the dep seems to become a hard requirement when there's no CC.

```
Entering B-Hooks-EndOfScope-0.14
Checking configure dependencies from META.json
Checking if you have ExtUtils::MakeMaker 6.58 ... Yes (6.66)
Checking if you have ExtUtils::CBuilder 0.26 ... Yes (0.280210)
Configuring B-Hooks-EndOfScope-0.14
Running Makefile.PL
Warning: prerequisite Tie::StdHash 0 not found.
Checking if your kit is complete...
Looks good
Writing Makefile for B::Hooks::EndOfScope
Writing MYMETA.yml and MYMETA.json
-> OK
Checking dependencies from MYMETA.json ...
Checking if you have Module::Runtime 0.014 ... Yes (0.014)
Checking if you have Hash::Util::FieldHash 0 ... Yes (1.10)
Checking if you have Tie::Hash 0 ... Yes (1.04)
Checking if you have Module::Implementation 0.06 ... Yes (0.09)
Checking if you have Scalar::Util 1.10 ... Yes (1.27)
Checking if you have base 0 ... Yes (2.18)
Checking if you have Tie::StdHash 0 ... No
Checking if you have strict 0 ... Yes (1.07)
Checking if you have constant 0 ... Yes (1.27)
Checking if you have warnings 0 ... Yes (1.18)
Checking if you have Sub::Exporter::Progressive 0.001011 ... Yes (0.001011)
==> Found dependencies: Tie::StdHash
Searching Tie::StdHash (0) on cpanmetadb ...
skipping S/SH/SHAY/perl-5.20.2.tar.gz
-> FAIL Installing the dependencies failed: Module 'Tie::StdHash' is not installed
-> FAIL Bailing out the installation for B-Hooks-EndOfScope-0.14.
```