### PR TITLE
work with Object::Remote by removing require() call on Tie::StdHash in PP

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for B-Hooks-EndOfScope
 
 {{$NEXT}}
+  - work with Object::Remote by removing require() call on Tie::StdHash in PP
 
 0.20      2016-05-06 16:42:50Z
   - remove unnecessary and erroneous extra crud in inc/

--- a/dist.ini
+++ b/dist.ini
@@ -37,7 +37,6 @@ Devel::Hide = 0.0007            ; releasers *must* test both the XS and PP paths
 -body = |  requires('constant');
 -body = |  if ("$]" < '5.010') {
 -body = |    requires('Scalar::Util');
--body = |    requires('base');
 -body = |  } else {
 -body = |    requires('Hash::Util::FieldHash');
 -body = |    requires('Tie::Hash');

--- a/lib/B/Hooks/EndOfScope/PP/FieldHash.pm
+++ b/lib/B/Hooks/EndOfScope/PP/FieldHash.pm
@@ -25,7 +25,7 @@ fieldhash my %hh;
 {
   package # hide from pause too
     B::Hooks::EndOfScope::PP::_TieHintHashFieldHash;
-  use base 'Tie::StdHash';  # in Tie::Hash, in core
+  our @ISA = ( 'Tie::StdHash' );  # in Tie::Hash, in core
   sub DELETE {
     my $ret = shift->SUPER::DELETE(@_);
     B::Hooks::EndOfScope::PP::__invoke_callback($_) for @$ret;


### PR DESCRIPTION
Since Tie::StdHash is in Tie::Hash, and base.pm triggers a require call on it, Object::Remote gets confused and tries to send Tie/StdHash.pm over the wire, which of course does not exist. Changing the `use base` call to `our @ISA` avoids that and makes BHEOS work fine with Object::Remote again.