### PR TITLE
Fix incorrect merge - $] *must* be referred to via a constant

### DIFF
--- a/lib/B/Hooks/EndOfScope/PP.pm
+++ b/lib/B/Hooks/EndOfScope/PP.pm
@@ -6,12 +6,14 @@ use strict;
 
 our $VERSION = '0.23';
 
+use constant _PERL_VERSION => "$]";
+
 BEGIN {
-  if ("$]" =~ /^5\.009/) {
+  if( _PERL_VERSION =~ /^5\.009/ ) {
     # CBA to figure out where %^H got broken and which H::U::HH is sane enough
     die "By design B::Hooks::EndOfScope does not operate in pure-perl mode on perl 5.9.X\n"
   }
-  elsif ("$]" < '5.010') {
+  elsif( _PERL_VERSION < 5.010 ) {
     require B::Hooks::EndOfScope::PP::HintHash;
     *on_scope_end = \&B::Hooks::EndOfScope::PP::HintHash::on_scope_end;
   }


### PR DESCRIPTION
Consider:

  ~$ perl -e '

    use warnings;
    use strict;

    use constant _PERL_VERSION => "$]";

    sub with_const {
      warn "stuff" if _PERL_VERSION > 5.006;
    }

    sub without_const {
      warn "stuff" if "$]" > 5.006;
    }

    use Data::Dumper;
    $Data::Dumper::Deparse = 1;
    warn Dumper [ \&with_const, \&without_const ];
  '

This reverts commit a2ff0a6617f0262d1512a70a2d46b4fe916cb0ec, and adds
an extra constant/guard to not leak an array when we don't need to.