### PR TITLE
switch from Variable::Magic to Variable::OnDestruct

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,7 +38,7 @@ Devel::Hide = 0.0007            ; releasers *must* test both the XS and PP paths
 -delimiter = |
 -body = |if ("$]" >= 5.008004 and want_xs()) {
 ;         IMPORTANT!!! when changing prereqs here, also update in B::Hooks::EndOfScope::XS
--body = |  requires('Variable::Magic', '0.48');
+-body = |  requires('Variable::OnDestruct', '0.07');
 -body = |
 -body = |  # make sure we smoke the pure-perl version fallback
 ;         IMPORTANT!!! when changing prereqs here, also update in t/10-test_without_vm_pure_pp.t

--- a/dist.ini
+++ b/dist.ini
@@ -34,9 +34,9 @@ Devel::Hide = 0.0007            ; releasers *must* test both the XS and PP paths
 
 ; authordep ExtUtils::HasCompiler = 0.014
 [DynamicPrereqs]
-:version = 0.029
+:version = 0.040
 -delimiter = |
--body = |if ("$]" >= 5.008004 and !want_pp() and can_xs()) {
+-body = |if ("$]" >= 5.008004 and want_xs()) {
 ;         IMPORTANT!!! when changing prereqs here, also update in B::Hooks::EndOfScope::XS
 -body = |  requires('Variable::Magic', '0.48');
 -body = |

--- a/lib/B/Hooks/EndOfScope/XS.pm
+++ b/lib/B/Hooks/EndOfScope/XS.pm
@@ -6,7 +6,7 @@ use warnings;
 
 our $VERSION = '0.27';
 
-# Limit the V::M-based (XS) version to perl 5.8.4+
+# Limit the Variable::OnDestruct-based (XS) version to perl 5.8.4+
 #
 # Given the unorthodox stuff we do to work around the hinthash double-free
 # might as well play it safe and only implement it in the PP version
@@ -15,33 +15,16 @@ our $VERSION = '0.27';
 #
 use 5.008004;
 
-use Variable::Magic 0.48 ();
+use Variable::OnDestruct 0.07 ();
 use Sub::Exporter::Progressive 0.001006 -setup => {
   exports => ['on_scope_end'],
   groups  => { default => ['on_scope_end'] },
 };
 
-my $wiz = Variable::Magic::wizard
-  data => sub { [$_[1]] },
-  free => sub { $_->() for @{ $_[1] }; () },
-  # When someone localise %^H, our magic doesn't want to be copied
-  # down. We want it to be around only for the scope we've initially
-  # attached ourselves to. Merely having MGf_LOCAL and a noop svt_local
-  # callback achieves this. If anything wants to attach more magic of our
-  # kind to a localised %^H, things will continue to just work as we'll be
-  # attached with a new and empty callback list.
-  local => \undef
-;
-
 sub on_scope_end (&) {
   $^H |= 0x020000;
 
-  if (my $stack = Variable::Magic::getdata %^H, $wiz) {
-    push @{ $stack }, $_[0];
-  }
-  else {
-    Variable::Magic::cast %^H, $wiz, $_[0];
-  }
+  Variable::OnDestruct::on_destruct_fifo(%^H, \&{$_[0]});
 }
 
 1;
@@ -52,8 +35,8 @@ __END__
 =head1 DESCRIPTION
 
 This is the implementation of L<B::Hooks::EndOfScope> based on
-L<Variable::Magic>, which is an XS module dependent on a compiler. It will
-always be automatically preferred if L<Variable::Magic> is available.
+L<Variable::OnDestruct>, which is an XS module dependent on a compiler. It will
+always be automatically preferred if L<Variable::OnDestruct> is available.
 
 =func on_scope_end
 

--- a/t/10-test_without_vm_pure_pp.t
+++ b/t/10-test_without_vm_pure_pp.t
@@ -36,7 +36,7 @@ for my $fn (@files) {
   note "retesting $fn";
   my @cmd = (
     $^X,
-    $has_dh ? '-MDevel::Hide=Variable::Magic' : (),
+    $has_dh ? '-MDevel::Hide=Variable::OnDestruct' : (),
     $fn
   );
 


### PR DESCRIPTION
The new Variable::OnDestruct version can match the semantics of how we were using Variable::Magic.