### PR TITLE
Revert to using Variable::Magic

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,7 +46,7 @@ Devel::Hide = 0.0007            ; releasers *must* test both the XS and PP imple
 -body = |if ("$]" >= 5.008004 and want_xs()) {
 ;         IMPORTANT!!! when changing prereqs here, also update in B::Hooks::EndOfScope::XS
 ;         and t/10-test_without_vm_pure_pp.t
--body = |  requires('Variable::OnDestruct', '0.07');
+-body = |  requires('Variable::Magic', '0.48');
 -body = |
 -body = |  # make sure we smoke the pure-perl version fallback
 ;         IMPORTANT!!! when changing prereqs here, also update in t/10-test_without_vm_pure_pp.t

--- a/dist.ini
+++ b/dist.ini
@@ -30,13 +30,13 @@ Scalar::Util = 0
 ; authordep Dist::Zilla::Plugin::SurgicalPodWeaver
 
 [Prereqs / RuntimeSuggests]
-Variable::OnDestruct = 0.07     ; for the XS implementation
+Variable::Magic = 0.48          ; for the XS implementation
 
 [Prereqs / TestSuggests]
 Devel::Hide = 0.0007            ; for testing the PP implementation
 
 [Prereqs / DevelopRequires]
-Variable::OnDestruct = 0.07
+Variable::Magic = 0.48
 Devel::Hide = 0.0007            ; releasers *must* test both the XS and PP implementations
 
 ; authordep ExtUtils::HasCompiler = 0.014

--- a/lib/B/Hooks/EndOfScope.pm
+++ b/lib/B/Hooks/EndOfScope.pm
@@ -51,10 +51,10 @@ This is exported by default. See L<Sub::Exporter> on how to customize it.
 
 =head2 Pure-perl mode caveat
 
-This caveat applies to B<any> version of perl where L<Variable::OnDestruct>
+This caveat applies to B<any> version of perl where L<Variable::Magic>
 is unavailable or otherwise disabled.
 
-While L<Variable::OnDestruct> has access to some very dark sorcery to make it
+While L<Variable::Magic> has access to some very dark sorcery to make it
 possible to throw an exception from within a callback, the pure-perl
 implementation does not have access to these hacks. Therefore, what
 would have been a B<compile-time exception> is instead B<converted to a
@@ -79,7 +79,7 @@ older perl versions, the implementation of B::Hooks::EndOfScope deliberately
 leaks a single empty hash for every scope being cleaned. This is done to
 avoid the memory corruption associated with the bug mentioned above.
 
-In order to stabilize this workaround use of L<Variable::OnDestruct> is disabled
+In order to stabilize this workaround use of L<Variable::Magic> is disabled
 on perls prior to version 5.8.4. On such systems loading/requesting
 L<B::Hooks::EndOfScope::XS> explicitly will result in a compile-time
 exception.
@@ -101,6 +101,6 @@ file F<t/02-localise.t> included with the distribution.
 
 L<Sub::Exporter>
 
-L<Variable::OnDestruct>
+L<Variable::Magic>
 
 =cut

--- a/lib/B/Hooks/EndOfScope/XS.pm
+++ b/lib/B/Hooks/EndOfScope/XS.pm
@@ -6,7 +6,7 @@ use warnings;
 
 our $VERSION = '0.28';
 
-# Limit the Variable::OnDestruct-based (XS) version to perl 5.8.4+
+# Limit the V::M-based (XS) version to perl 5.8.4+
 #
 # Given the unorthodox stuff we do to work around the hinthash double-free
 # might as well play it safe and only implement it in the PP version
@@ -15,16 +15,33 @@ our $VERSION = '0.28';
 #
 use 5.008004;
 
-use Variable::OnDestruct 0.07 ();
+use Variable::Magic 0.48 ();
 use Sub::Exporter::Progressive 0.001006 -setup => {
   exports => ['on_scope_end'],
   groups  => { default => ['on_scope_end'] },
 };
 
+my $wiz = Variable::Magic::wizard
+  data => sub { [$_[1]] },
+  free => sub { $_->() for @{ $_[1] }; () },
+  # When someone localise %^H, our magic doesn't want to be copied
+  # down. We want it to be around only for the scope we've initially
+  # attached ourselves to. Merely having MGf_LOCAL and a noop svt_local
+  # callback achieves this. If anything wants to attach more magic of our
+  # kind to a localised %^H, things will continue to just work as we'll be
+  # attached with a new and empty callback list.
+  local => \undef
+;
+
 sub on_scope_end (&) {
   $^H |= 0x020000;
 
-  Variable::OnDestruct::on_destruct_fifo(%^H, \&{$_[0]});
+  if (my $stack = Variable::Magic::getdata %^H, $wiz) {
+    push @{ $stack }, $_[0];
+  }
+  else {
+    Variable::Magic::cast %^H, $wiz, $_[0];
+  }
 }
 
 1;
@@ -35,8 +52,8 @@ __END__
 =head1 DESCRIPTION
 
 This is the implementation of L<B::Hooks::EndOfScope> based on
-L<Variable::OnDestruct>, which is an XS module dependent on a compiler. It will
-always be automatically preferred if L<Variable::OnDestruct> is available.
+L<Variable::Magic>, which is an XS module dependent on a compiler. It will
+always be automatically preferred if L<Variable::Magic> is available.
 
 =func on_scope_end
 

--- a/t/10-test_without_vm_pure_pp.t
+++ b/t/10-test_without_vm_pure_pp.t
@@ -36,7 +36,7 @@ for my $fn (@files) {
   note "retesting $fn";
   my @cmd = (
     $^X,
-    $has_dh ? '-MDevel::Hide=Variable::OnDestruct' : (),
+    $has_dh ? '-MDevel::Hide=Variable::Magic' : (),
     $fn
   );
 


### PR DESCRIPTION
Using Variable::OnDestruct is causing segfaults in perl versions older than 5.34, and it seems to not be a trivial fix. And Variable::Magic is no longer broken on blead.

Fixes https://rt.cpan.org/Ticket/Display.html?id=152080